### PR TITLE
印鑑画像を表記するAPIエンドポイントを実装

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -39,6 +39,9 @@ gem "rack-cors"
 gem "devise"
 gem "devise-jwt"
 
+# Use MiniMagick for image processing
+gem "mini_magick"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -160,6 +160,9 @@ GEM
       net-pop
       net-smtp
     marcel (1.0.4)
+    mini_magick (5.1.2)
+      benchmark
+      logger
     mini_mime (1.1.5)
     minitest (5.25.4)
     msgpack (1.8.0)
@@ -352,6 +355,7 @@ DEPENDENCIES
   factory_bot_rails
   faker
   kamal
+  mini_magick
   pg (~> 1.1)
   puma (>= 5.0)
   rack-cors

--- a/backend/app/controllers/api/v1/stamps_controller.rb
+++ b/backend/app/controllers/api/v1/stamps_controller.rb
@@ -1,0 +1,36 @@
+class Api::V1::StampsController < ApplicationController
+  def preview
+    stamp = Stamp.new(stamp_params)
+
+    if stamp.invalid?
+      render json: { errors: stamp.errors.full_messages }, status: :unprocessable_entity
+      return
+    end
+
+    image = if stamp.advanced?
+              stamp.build_image_advanced
+            else
+              stamp.build_image
+            end
+
+    send_data image.to_blob, type: 'image/png', disposition: 'inline'
+  end
+
+  private
+
+  def stamp_params
+    params.permit(
+      :stamp_category,
+      :stamp_type,
+      :engraving_type,
+      :font,
+      :text_1,
+      :text_2,
+      :text_3,
+      :balance,
+      :is_advanced
+    ).tap do |params|
+      params[:is_advanced] = params[:is_advanced] == 'true'
+    end
+  end
+end

--- a/backend/app/models/stamp.rb
+++ b/backend/app/models/stamp.rb
@@ -1,0 +1,113 @@
+require 'mini_magick'
+
+class Stamp
+  include ActiveModel::API
+  include ActiveModel::Attributes
+
+  INKANHONPO_BASE_URL = 'https://www.inkan-honpo.com/stampImage.cgi?'.freeze
+  STAMP_SIZE = 500.freeze
+  DOT = 1.freeze
+  ROTATE_CHAR = '%81[%81\%81|%81]-%81F:%81^/%81`'.freeze
+  ASPECT_RATIO = 1.freeze
+  CENTER_HEIGHT = 0.36.freeze
+  DATE_SAMPLE_HEIGHT = 0.12.freeze
+  DATE_SAMPLE_WIDTH = 0.62.freeze
+  LINE_LAYOUT = 'center'.freeze
+  MARGIN = 20.freeze
+
+  attribute :stamp_category, :string
+  attribute :stamp_type, :string
+  attribute :engraving_type, :string
+  attribute :font, :string
+  attribute :text_1, :string
+  attribute :text_2, :string
+  attribute :text_3, :string
+  attribute :is_advanced, :boolean
+  attribute :balance, :string
+
+  validates :stamp_category, :stamp_type, :engraving_type, :font, :balance, presence: true
+  validates :is_advanced, inclusion: { in: [true, false] }
+
+  def advanced?
+    is_advanced
+  end
+
+  def build_image
+    image_url = build_image_url
+
+    MiniMagick::Image.open(image_url)
+  end
+
+  def build_image_advanced
+    image_url = build_image_url
+    image = MiniMagick::Image.open(image_url)
+
+    remove_white_background(image)
+  end
+
+  private
+
+  def build_image_url
+    base_url = INKANHONPO_BASE_URL
+    query = build_query
+
+    "#{base_url}#{query.to_query}"
+  end
+
+  def build_query
+    query = {
+      command: fetch_query(:command),
+      type: fetch_query(:type),
+      columnSize: fetch_query(:column_size),
+      vector: fetch_query(:vector),
+      font: fetch_query(:font),
+      frameWidth: fetch_query(:frame_width),
+      balance: fetch_query(:balance),
+      stampSize: STAMP_SIZE,
+      dot: DOT,
+      rotateChar: ROTATE_CHAR,
+      aspectRatio: ASPECT_RATIO,
+      centerHeight: CENTER_HEIGHT,
+      dateSampleHeight: DATE_SAMPLE_HEIGHT,
+      dateSampleWidth: DATE_SAMPLE_WIDTH,
+      line1Layout: LINE_LAYOUT,
+      line2Layout: LINE_LAYOUT,
+      line3Layout: LINE_LAYOUT,
+      line4Layout: LINE_LAYOUT,
+      margin: MARGIN,
+    }
+
+    text_keys = fetch_query(:text_keys)
+
+    if text_keys.present?
+      text_values = [text_1, text_2, text_3]
+      text_keys.each_with_index do |key, i|
+        text_value = text_values[i]
+        text_value = text_value.encode('Shift_JIS') if text_value.present? && key != :dateSample
+        query = query.merge({ key => text_value })
+      end
+    end
+
+    query
+  end
+
+  def fetch_query(property)
+    stamp_queries = Rails.application.config.stamp_queries
+
+    case property
+    when :balance
+      stamp_queries.dig(property, balance.to_sym)
+    when :font
+      stamp_queries.dig(property, stamp_category.to_sym, stamp_type.to_sym, font.to_sym)
+    else
+      stamp_queries.dig(property, stamp_category.to_sym, stamp_type.to_sym, engraving_type.to_sym)
+    end
+  end
+
+  def remove_white_background(image)
+    image.combine_options do |c|
+      c.fuzz '40%'
+      c.transparent 'white'
+    end
+  end
+end

--- a/backend/app/models/stamp_download.rb
+++ b/backend/app/models/stamp_download.rb
@@ -5,6 +5,7 @@ class StampDownload < ApplicationRecord
   validates :stamp_type, presence: true
   validates :engraving_type, presence: true
   validates :font, presence: true
+  validates :balance, inclusion: { in: %w[large medium small] }
   validates :is_advanced, inclusion: { in: [true, false] }
 
   def advanced?

--- a/backend/config/initializers/stamp_options.rb
+++ b/backend/config/initializers/stamp_options.rb
@@ -191,4 +191,6 @@ Rails.application.config.stamp_options = {
 			},
  	  },
   },
+
+	balance: %w[large medium small],
 }

--- a/backend/config/initializers/stamp_queries.rb
+++ b/backend/config/initializers/stamp_queries.rb
@@ -1,0 +1,378 @@
+Rails.application.config.stamp_queries = {
+
+	font: {
+		personal: {
+			official: {
+				insotai: '0',
+				tenshotai: '1',
+				kointai: '2',
+				reishotai: '3',
+				gyoushotai: '4',
+				kaishotai: '5',
+			},
+			approval: {
+				insotai: '0',
+				tenshotai: '1',
+				kointai: '2',
+				reishotai: '3',
+				gyoushotai: '4',
+				kaishotai: '5',
+			},
+			shachihata: {
+				no_option: '16',
+			},
+		},
+		company: {
+			representative: {
+				insotai: '0',
+				tenshotai: '1',
+				kointai: '2',
+				reishotai: '3',
+				gyoushotai: '4',
+				kaishotai: '5',
+			},
+			square: {
+				insotai: '0',
+				tenshotai: '1',
+				kointai: '2',
+				reishotai: '3',
+				gyoushotai: '4',
+				kaishotai: '5',
+			},
+		},
+		date: {
+			circle: {
+				minchotai: '0',
+				bold_mincho: '1',
+				square_gothic: '2',
+				circle_gothic: '4',
+				kaishotai: '6',
+				gyoushotai: '7',
+				kointai: '8',
+				reishotai: '9',
+				tenshotai: '12',
+				soushotai: '11',
+				insotai: '13',
+			},
+			square: {
+				minchotai: '0',
+				bold_mincho: '1',
+				square_gothic: '2',
+				circle_gothic: '4',
+				kaishotai: '6',
+				gyoushotai: '7',
+				kointai: '8',
+				reishotai: '9',
+				tenshotai: '12',
+				soushotai: '11',
+				insotai: '13',
+			},
+		},
+	},
+
+	command: {
+		personal: {
+			official: {
+				one_row: 'kojinin',
+				one_row_old: 'kojinin',
+				two_rows: 'kojinin',
+				one_col: 'kojinin',
+				two_cols: 'kojinin',
+			},
+			approval: {
+				one_row: 'kojinin',
+				one_row_old: 'kojinin',
+				two_rows: 'kojinin',
+				one_col: 'kojinin',
+				two_cols: 'kojinin',
+			},
+			shachihata: {
+				no_option: 'kojinin',
+			},
+		},
+		company: {
+			representative: {
+				circle_center: 'yakusyokuin',
+				circle_center_one_row: 'yakusyokuin',
+				circle_center_two_rows: 'yakusyokuin',
+				no_circle: 'shikakusyain',
+				no_circle_one_row: 'shikakusyain',
+				no_circle_two_rows: 'shikakusyain',
+			},
+			square: {
+				row: 'kakuin',
+				one_row: 'kakuin',
+				two_rows: 'kakuin',
+				three_rows: 'kakuin',
+				col: 'kakuin',
+				one_col: 'kakuin',
+				two_cols: 'kakuin',
+				three_cols: 'kakuin',
+			},
+		},
+		date: {
+			circle: {
+				no_option: 'dateStamp',
+			},
+			square: {
+				no_option: 'dateStampKaku',
+			},
+		},
+	},
+
+	type: {
+		personal: {
+			official: {
+				one_row: '3',
+				one_row_old: '1',
+				two_rows: '4',
+				one_col: '2',
+				two_cols: '0',
+			},
+			approval: {
+				one_row: '3',
+				one_row_old: '1',
+				two_rows: '4',
+				one_col: '2',
+				two_cols: '0',
+			},
+			shachihata: {
+				no_option: '2',
+			}
+		},
+		company: {
+			representative: {
+				circle_center: '0',
+				circle_center_one_row: '0',
+				circle_center_two_rows: '0',
+				no_circle: '1',
+				no_circle_one_row: '1',
+				no_circle_two_rows: '1',
+			},
+			square: {
+				row: '',
+				one_row: '',
+				two_rows: '',
+				three_rows: '',
+				col: '',
+				one_col: '',
+				two_cols: '',
+				three_cols: '',
+			},
+		},
+		date: {
+			circle: {
+				no_option: '',
+			},
+			square: {
+				no_option: '',
+			},
+		},
+	},
+
+	column_size: {
+		personal: {
+			official: {
+				one_row: '',
+				one_row_old: '',
+				two_rows: '',
+				one_col: '',
+				two_cols: '',
+			},
+			approval: {
+				one_row: '',
+				one_row_old: '',
+				two_rows: '',
+				one_col: '',
+				two_cols: '',
+			},
+			shachihata: {
+				no_option: '',
+			}
+		},
+		company: {
+			representative: {
+				circle_center: '0',
+				circle_center_one_row: '1',
+				circle_center_two_rows: '2',
+				no_circle: '0',
+				no_circle_one_row: '1',
+				no_circle_two_rows: '2',
+			},
+			square: {
+				row: '0',
+				one_row: '1',
+				two_rows: '2',
+				three_rows: '3',
+				col: '0',
+				one_col: '1',
+				two_cols: '2',
+				three_cols: '3',
+			},
+		},
+		date: {
+			circle: {
+				no_option: '',
+			},
+			square: {
+				no_option: '',
+			},
+		},
+	},
+
+	frame_width: {
+		personal: {
+			official: {
+				one_row: '4',
+				one_row_old: '4',
+				two_rows: '4',
+				one_col: '4',
+				two_cols: '4',
+			},
+			approval: {
+				one_row: '4',
+				one_row_old: '4',
+				two_rows: '4',
+				one_col: '4',
+				two_cols: '4',
+			},
+			shachihata: {
+				no_option: '4',
+			}
+		},
+		company: {
+			representative: {
+				circle_center: '6',
+				circle_center_one_row: '6',
+				circle_center_two_rows: '6',
+				no_circle: '6',
+				no_circle_one_row: '6',
+				no_circle_two_rows: '6',
+			},
+			square: {
+				row: '6',
+				one_row: '6',
+				two_rows: '6',
+				three_rows: '6',
+				col: '6',
+				one_col: '6',
+				two_cols: '6',
+				three_cols: '6',
+			},
+		},
+		date: {
+			circle: {
+				no_option: '6',
+			},
+			square: {
+				no_option: '6',
+			},
+		},
+	},
+
+	vector: {
+		personal: {
+			official: {
+				one_row: '',
+				one_row_old: '',
+				two_rows: '',
+				one_col: '',
+				two_cols: '',
+			},
+			approval: {
+				one_row: '',
+				one_row_old: '',
+				two_rows: '',
+				one_col: '',
+				two_cols: '',
+			},
+			shachihata: {
+				no_option: '',
+			}
+		},
+		company: {
+			representative: {
+				circle_center: '',
+				circle_center_one_row: '',
+				circle_center_two_rows: '',
+				no_circle: '',
+				no_circle_one_row: '',
+				no_circle_two_rows: '',
+			},
+			square: {
+				row: '0',
+				one_row: '0',
+				two_rows: '0',
+				three_rows: '0',
+				col: '1',
+				one_col: '1',
+				two_cols: '1',
+				three_cols: '1',
+			},
+		},
+		date: {
+			circle: {
+				no_option: '',
+			},
+			square: {
+				no_option: '',
+			},
+		},
+	},
+
+	balance: {
+		'large': '0',
+		'medium': '1',
+		'small': '2',
+	},
+
+	text_keys: {
+		personal: {
+			official: {
+				one_row: ['stampNamePersonal1', 'dummyQuery', 'dummyQuery'],
+				one_row_old: ['stampNamePersonal1', 'dummyQuery', 'dummyQuery'],
+				two_rows: ['stampNamePersonal1', 'stampNamePersonal2', 'dummyQuery'],
+				one_col: ['stampNamePersonal1', 'dummyQuery', 'dummyQuery'],
+				two_cols: ['stampNamePersonal1', 'stampNamePersonal2', 'dummyQuery'],
+			},
+			approval: {
+				one_row: ['stampNamePersonal1', 'dummyQuery', 'dummyQuery'],
+				one_row_old: ['stampNamePersonal1', 'dummyQuery', 'dummyQuery'],
+				two_rows: ['stampNamePersonal1', 'stampNamePersonal2', 'dummyQuery'],
+				one_col: ['stampNamePersonal1', 'dummyQuery', 'dummyQuery'],
+				two_cols: ['stampNamePersonal1', 'stampNamePersonal2', 'dummyQuery'],
+			},
+			shachihata: {
+				no_option: ['stampNamePersonal1', 'dummyQuery', 'dummyQuery'],
+			}
+		},
+		company: {
+			representative: {
+				circle_center: ['stampNameCorporation', 'stampNameBussiness', 'dummyQuery'],
+				circle_center_one_row: ['stampNameCorporation', 'stampNameBussiness1', 'dummyQuery'],
+				circle_center_two_rows: ['stampNameCorporation', 'stampNameBussiness1', 'stampNameBussiness2'],
+				no_circle: ['stampNameBussiness', 'dummyQuery', 'dummyQuery'],
+				no_circle_one_row: ['stampNameBussiness1', 'dummyQuery', 'dummyQuery'],
+				no_circle_two_rows: ['stampNameBussiness1', 'stampNameBussiness2', 'dummyQuery'],
+			},
+			square: {
+				row: ['stampNameBussiness', 'dummyQuery', 'dummyQuery'],
+				one_row: ['stampNameBussiness1', 'dummyQuery', 'dummyQuery'],
+				two_rows: ['stampNameBussiness1', 'stampNameBussiness2', 'dummyQuery'],
+				three_rows: ['stampNameBussiness1', 'stampNameBussiness2', 'stampNameBussiness3'],
+				col: ['stampNameBussiness', 'dummyQuery', 'dummyQuery'],
+				one_col: ['stampNameBussiness1', 'dummyQuery', 'dummyQuery'],
+				two_cols: ['stampNameBussiness1', 'stampNameBussiness2', 'dummyQuery'],
+				three_cols: ['stampNameBussiness1', 'stampNameBussiness2', 'stampNameBussiness3'],
+			},
+		},
+		date: {
+			circle: {
+				no_option: ['line1String', 'dateSample', 'line4String'],
+			},
+			square: {
+				no_option: ['line1String', 'dateSample', 'line3String'],
+			},
+		},
+	},
+}

--- a/backend/db/migrate/20250224021616_add_balance_to_stamp_downloads.rb
+++ b/backend/db/migrate/20250224021616_add_balance_to_stamp_downloads.rb
@@ -1,0 +1,5 @@
+class AddBalanceToStampDownloads < ActiveRecord::Migration[8.0]
+  def change
+    add_column :stamp_downloads, :balance, :string
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_16_070315) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_24_021616) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -34,6 +34,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_16_070315) do
     t.bigint "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "balance"
     t.index ["user_id"], name: "index_stamp_downloads_on_user_id"
   end
 

--- a/backend/spec/factories/stamp_downloads.rb
+++ b/backend/spec/factories/stamp_downloads.rb
@@ -16,6 +16,8 @@ FactoryBot.define do
 
     is_advanced { false }
 
+    balance { %w[large medium small].sample }
+
     association :user
 
     trait :advanced do

--- a/backend/spec/factories/stamps.rb
+++ b/backend/spec/factories/stamps.rb
@@ -1,0 +1,25 @@
+FactoryBot.define do
+  factory :stamp do
+    stamp_options = Rails.application.config.stamp_options
+
+    stamp_category { stamp_options[:stamp_categories].keys.sample }
+
+    stamp_type { stamp_options[:stamp_types][stamp_category.to_sym].keys.sample }
+
+    engraving_type { stamp_options[:engraving_types][stamp_category.to_sym][stamp_type.to_sym].keys.sample }
+
+    font { stamp_options[:fonts][stamp_category.to_sym][stamp_type.to_sym].keys.sample }
+
+    text_1 { Faker::Name.name }
+    text_2 { Faker::Name.name }
+    text_3 { Faker::Name.name }
+
+    is_advanced { false }
+
+    balance { %w[large medium small].sample }
+
+    trait :advanced do
+      is_advanced { true }
+    end
+  end
+end

--- a/backend/spec/models/stamp_download_spec.rb
+++ b/backend/spec/models/stamp_download_spec.rb
@@ -33,6 +33,11 @@ RSpec.describe StampDownload, type: :model do
       expect(stamp_download).to_not be_valid
     end
 
+    it 'is not valid without a balance' do
+      stamp_download.balance = nil
+      expect(stamp_download).to_not be_valid
+    end
+
     it 'is valid without text' do
       stamp_download.text_1 = nil
       expect(stamp_download).to be_valid

--- a/backend/spec/models/stamp_spec.rb
+++ b/backend/spec/models/stamp_spec.rb
@@ -1,0 +1,87 @@
+require 'rails_helper'
+
+RSpec.describe Stamp, type: :model do
+
+  describe 'validations' do
+    let(:stamp) { FactoryBot.build(:stamp) }
+
+    it 'is valid with valid attributes' do
+      expect(stamp).to be_valid
+    end
+
+    it 'is not valid without a stamp_category' do
+      stamp.stamp_category = nil
+      expect(stamp).to_not be_valid
+    end
+
+    it 'is not valid without a stamp_type' do
+      stamp.stamp_type = nil
+      expect(stamp).to_not be_valid
+    end
+
+    it 'is not valid without an engraving_type' do
+      stamp.engraving_type = nil
+      expect(stamp).to_not be_valid
+    end
+
+    it 'is not valid without a font' do
+      stamp.font = nil
+      expect(stamp).to_not be_valid
+    end
+
+    it 'is valid without text' do
+      stamp.text_1 = nil
+      expect(stamp).to be_valid
+    end
+
+    it 'is not valid if is_advanced is not included in [true, false]' do
+      stamp.balance = nil
+      expect(stamp).to_not be_valid
+    end
+  end
+
+  describe '#advanced?' do
+    let(:stamp) { FactoryBot.build(:stamp) }
+    let(:stamp_advanced) { FactoryBot.build(:stamp, :advanced) }
+
+    it 'is true when is_advanced is true' do
+      expect(stamp_advanced.advanced?).to be true
+    end
+
+    it 'is false when is_advanced is false' do
+      expect(stamp.advanced?).to be false
+    end
+  end
+
+  describe '#build_image / #build_image_advanced' do
+    let(:stamp) { FactoryBot.build(:stamp) }
+    let(:fake_url) { 'https://placehold.jp/150x150.png' }
+    let(:mock_image) { instance_double(MiniMagick::Image) }
+
+    before do
+      allow(stamp).to receive(:build_image_url).and_return(fake_url)
+      allow(MiniMagick::Image).to receive(:open).with(fake_url).and_return(mock_image)
+      allow(stamp).to receive(:remove_white_background).with(mock_image).and_return(mock_image)
+    end
+
+    it 'returns MiniMagick::Image object with build_image' do
+      image = stamp.build_image
+
+      aggregate_failures do
+        expect(stamp).to have_received(:build_image_url)
+        expect(stamp).not_to have_received(:remove_white_background)
+        expect(image).to eq mock_image
+      end
+    end
+
+    it 'returns MiniMagick::Image object with build_image_advanced' do
+      image = stamp.build_image_advanced
+
+      aggregate_failures do
+        expect(stamp).to have_received(:build_image_url)
+        expect(stamp).to have_received(:remove_white_background).with(mock_image)
+        expect(image).to eq mock_image
+      end
+    end
+  end
+end

--- a/backend/spec/requests/stamps_spec.rb
+++ b/backend/spec/requests/stamps_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe "Stamps", type: :request do
+  describe "GET /api/v1/stamps/preview" do
+    context 'not advanced stamp' do
+      let(:stamp) { FactoryBot.build(:stamp) }
+
+      it 'returns PNG image' do
+        get api_v1_stamps_preview_path(stamp.attributes)
+
+        aggregate_failures do
+          expect(response).to have_http_status(:ok)
+          expect(response.content_type).to eq('image/png')
+        end
+      end
+    end
+
+    context 'advanced stamp' do
+      let(:stamp) { FactoryBot.build(:stamp, :advanced) }
+
+      it 'returns PNG image' do
+        get api_v1_stamps_preview_path(stamp.attributes)
+
+        aggregate_failures do
+          expect(response).to have_http_status(:ok)
+          expect(response.content_type).to eq('image/png')
+        end
+      end
+    end
+
+    context 'invalid stamp' do
+      let(:stamp) { FactoryBot.build(:stamp) }
+
+      it 'returns unprocessable entity' do
+        stamp.stamp_category = nil
+        get api_v1_stamps_preview_path(stamp.attributes)
+
+        aggregate_failures do
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response.content_type).to eq('application/json; charset=utf-8')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Stampモデルの実装
  - 白抜きにする画像を返すメソッドとそうでないメソッドを整備
- Stampsコントローラの実装
  - 受け取ったクエリパラメータによって、上記のメソッドのどちらを使うかを制御
- 上記に対応するRSpecの整備
- stamp_downloadsテーブルにbalanceカラムを追加し、それに対応するモデルにbalance属性を追加