### PR TITLE
印鑑ダウンロード時に履歴を保存する機能を実装

### DIFF
--- a/backend/app/controllers/api/v1/stamp_downloads_controller.rb
+++ b/backend/app/controllers/api/v1/stamp_downloads_controller.rb
@@ -1,0 +1,33 @@
+class Api::V1::StampDownloadsController < ApplicationController
+  def create
+    stamp_download = StampDownload.new(stamp_download_params)
+
+    if stamp_download.save
+      render json: {
+        errors: nil,
+      }, status: :created
+    else
+      render json: {
+        errors: stamp_download.errors.full_messages,
+      }, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def stamp_download_params
+    params.permit(
+      :stamp_category,
+      :stamp_type,
+      :engraving_type,
+      :font,
+      :text_1,
+      :text_2,
+      :text_3,
+      :balance,
+      :is_advanced
+    ).tap do |p|
+      p[:is_advanced] = p[:is_advanced] == 'true'
+    end
+  end
+end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -19,11 +19,11 @@ Rails.application.routes.draw do
 
       resources :users
 
-      resources :stamps_downloads, only: :create
+      resources :stamp_downloads, only: :create
 
-      resources :stamps_downloads, only: :index do
+      resources :stamp_downloads, only: :index do
         collection do
-          get 'users/:id', to: 'stamps_downloads#user_index'
+          get 'users/:id', to: 'stamp_downloads#user_index'
         end
       end
 

--- a/backend/spec/requests/stamp_downloads_spec.rb
+++ b/backend/spec/requests/stamp_downloads_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe "StampDownloads", type: :request do
+  describe "POST /api/v1/stamp_downloads" do
+    let(:stamp_download) { FactoryBot.build(:stamp_download)}
+
+    context 'valid stamp' do
+      it 'creates a stamp_download' do
+        post api_v1_stamp_downloads_path(stamp_download.attributes)
+
+        body = JSON.parse(response.body)
+
+        aggregate_failures do
+          expect(response).to have_http_status(:created)
+          expect(body['errors']).to be_nil
+        end
+      end
+    end
+
+    context 'invalid stamp' do
+      it 'returns unprocessable entity' do
+        stamp_download.stamp_category = nil
+        post api_v1_stamp_downloads_path(stamp_download.attributes)
+
+        body = JSON.parse(response.body)
+
+        aggregate_failures do
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(body['errors']).to_not be_nil
+        end
+      end
+    end
+  end
+end

--- a/frontend/app/src/hooks/useCreateStampDownload.ts
+++ b/frontend/app/src/hooks/useCreateStampDownload.ts
@@ -1,0 +1,34 @@
+import { useState } from "react";
+import { apiClient } from "../lib/apiClient";
+import { CreateStampDownloadProps, StampDownloadRequest, StampDownloadResponse } from "../types/StampDownload";
+
+export const useCreateStampDownload = () => {
+  const [statusDownload, setStatusDownload] = useState<string>('before');
+  const [errorMessageDownload, setErrorMessageDownload] = useState<string>('');
+
+  const createStampDownload = async (params: CreateStampDownloadProps) => {
+    try {
+      setStatusDownload('running');
+      const requestPayload: StampDownloadRequest = params;
+
+      const response = await apiClient.post<StampDownloadResponse>(
+        '/stamp_downloads',
+        requestPayload,
+      );
+
+      const status = response.data.errors ? 'error' : 'success';
+
+      setStatusDownload(status);
+      setErrorMessageDownload(response.data.errors ? response.data.errors.join(', ') : '');
+    } catch (error: any) {
+      setStatusDownload('error');
+      setErrorMessageDownload(error.message);
+    };
+  }
+
+  return {
+    statusDownload,
+    errorMessageDownload,
+    createStampDownload,
+  }
+}

--- a/frontend/app/src/types/StampDownload.ts
+++ b/frontend/app/src/types/StampDownload.ts
@@ -1,0 +1,9 @@
+import { StampProps } from './Stamp';
+
+export type CreateStampDownloadProps = StampProps;
+
+export type StampDownloadRequest = StampProps;
+
+export type StampDownloadResponse = { 
+  errors: string[] | null;
+};


### PR DESCRIPTION
- 印鑑ダウンロード時にその履歴をstamp_downloadsテーブルに保存するエンドポイントを実装
- 上記のエンドポイントに対してリクエストを行うフックを実装
- 上記のフックを印鑑編集ダイアログに追加